### PR TITLE
Update Docker instructions for the current image lineup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,31 +31,43 @@ In addition, pregenerated versions of them are available for both the master and
 
 ## Docker container
 
-The workshop dependencies and data files are available in a Docker container running PostgreSQL-15, PostGIS-3.4 and MobilityDB-develop (version 1.1).
+A prebuilt Docker image is available with PostgreSQL 18, PostGIS 3.6, and MobilityDB 1.3.
 
-*  Pull the prebuilt image from the [Docker Hub Registry](https://hub.docker.com/r/mobilitydb/mobilitydb).
+* Pull the image and create a persistent volume:
 
     ```bash
-    docker pull mobilitydb/mobilitydb:15-3.4-develop
-    ```
-
-*  Create a Docker volume to preserve the PostgreSQL database files outside of the container.
-    ```bash
+    docker pull mobilitydb/mobilitydb:18-3.6-1.3
     docker volume create mobilitydb_data
     ```
- *  Run the Docker container.
+
+* Unzip the workshop data files on the host so the container can read them through a bind-mount:
+
     ```bash
-    docker run --name "mobilitydb" -d -p 5432 -v mobilitydb_data:/var/lib/postgresql mobilitydb/mobilitydb:12-2.5-develop-workshop 
+    cd data && unzip -o ais_data.zip && unzip -o gtfs_data.zip && cd ..
     ```
- *  Enter into the Docker container.
+
+    This produces `data/ais.csv` and the GTFS files (`data/stops.txt`, `data/routes.txt`, etc.).
+
+* Run the container, mounting `data/` at `/workshopData/` inside it:
+
     ```bash
-    docker exec -it mobilitydb bash
+    docker run --name mobilitydb -d \
+        -e POSTGRES_USER=docker \
+        -e POSTGRES_PASSWORD=docker \
+        -e POSTGRES_DB=mobilitydb \
+        -p 5432:5432 \
+        -v mobilitydb_data:/var/lib/postgresql \
+        -v "$(pwd)/data":/workshopData \
+        mobilitydb/mobilitydb:18-3.6-1.3
     ```
- *  Connect to the database  (username=docker, db=mobilitydb).
+
+    The workshop data files are then accessible inside the container under `/workshopData/`. Chapters that load CSV/TXT files can `\copy` from there, e.g. `\copy stops FROM '/workshopData/stops.txt' DELIMITER ',' CSV HEADER`.
+
+* Connect to the database:
+
     ```bash
-    psql -U docker -d mobilitydb 
+    docker exec -it mobilitydb psql -U docker -d mobilitydb
     ```
- *  The workshop data files are available in the workshop directory inside the container.
 
 
 ## License


### PR DESCRIPTION
The Docker section pointed at retired images (`mobilitydb/mobilitydb:15-3.4-develop`, `mobilitydb/mobilitydb:12-2.5-develop-workshop`). Switch to `mobilitydb/mobilitydb:18-3.6-1.3`, pass `POSTGRES_USER`/`POSTGRES_PASSWORD`/`POSTGRES_DB` explicitly (the current image bakes no defaults for them), and bind-mount `data/` at `/workshopData/` since workshop data is no longer pre-bundled.