### PR TITLE
Build the workshop documentation on the master branch

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -9,7 +9,6 @@ on:
       - 'docs/**'
     branches:
       - master
-      - develop
 
 jobs:
   build:
@@ -42,7 +41,7 @@ jobs:
 
       # store the documentation files
       - name: Upload output directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: doc-files
           path: |
@@ -62,13 +61,13 @@ jobs:
 
     steps:
       # checkout the gh-pages branch
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: gh-pages
 
       # download the doc files, most of which are generated above
       - name: Download output directory
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: doc-files
           path: docs-temp
@@ -79,13 +78,6 @@ jobs:
         run: |
           rm -rf master
           mv docs-temp master
-
-      # Rename the directory to master
-      - name: Rename the directory to develop
-        if: ${{ github.ref == 'refs/heads/develop' }}
-        run: |
-          rm -rf develop
-          mv docs-temp develop
 
       # add, commit and push to gh-pages
       - name: Commit changes


### PR DESCRIPTION
The documentation workflow runs on the master branch and uses the v4 checkout and artifact actions.